### PR TITLE
feat: add show more button to client and provider 

### DIFF
--- a/web/public/index.html
+++ b/web/public/index.html
@@ -14,6 +14,10 @@
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
     -->
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200"
+    />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.

--- a/web/src/components/pages/client/dashboard/ClientDashboard.css
+++ b/web/src/components/pages/client/dashboard/ClientDashboard.css
@@ -39,7 +39,7 @@
     margin-top: 20px;
   }
   
-  .dashboard-action button {
+  .dashboard-action button, .show_more__btn {
     background-color: #28a745;
     border: none;
     border-radius: 5px;
@@ -47,17 +47,47 @@
     padding: 10px 20px;
     cursor: pointer;
   }
+
   
   .dashboard-action button:hover {
     background-color: #218838;
   }
   
+  .show_more__btn {
+    background: rgba(34, 153, 84, 0.85);
+    width: 15%;
+    border-radius: 5rem;
+    margin: auto auto;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    text-decoration: none;
+    font-weight: bold;
+  }
+
+  .show_more__btn:hover {
+    background: #007bff;
+    
+  }
+
+  .show_more__btn span:nth-child(2) {
+    font-size: 1.2em;
+  }
+
+
+  .show_more__btn span:nth-child(1):hover {
+    text-decoration: underline;
+    text-underline-offset: 5px;
+  }
+
+
   /* Service list styles */
   .services-list {
     display: flex;
     flex-wrap: wrap;
     gap: 20px;
     justify-content: center;
+    margin-bottom: 1rem;
   }
   
   /* Individual service item styles */

--- a/web/src/components/pages/client/dashboard/ClientDashboard.jsx
+++ b/web/src/components/pages/client/dashboard/ClientDashboard.jsx
@@ -7,7 +7,7 @@ import '../dashboard/ClientDashboard.css';
 
 const ClientHomePage = () => {
   const [user, setUser] = useState({ name: 'Guest', role: 'client', rating: '3' });
-  const [, setServices] = useState([]);
+  const [services, setServices] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -44,29 +44,6 @@ const ClientHomePage = () => {
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error: {error}</div>;
 
-  const serv = [
-        {
-            id: 1,
-            name: 'Web Development',
-            description: 'Web Development',
-            price: 1000,
-            providerId: {
-                id: '02',
-                name: 'Josue Batey',
-            }
-    },
-    {
-            id: 2,
-            name: 'Mobile Development',
-            description: 'iOS Development',
-            price: 1000,
-            providerId: {
-                id: '02',
-                name: 'Josue Batey',
-            }
-    }
-]
-
   return (
     <>
       <Header />
@@ -82,7 +59,7 @@ const ClientHomePage = () => {
         <section className="services-overview">
           <h2>Explore Services</h2>
           <div className="services-list">
-            {serv.map(service => (
+            {services.map(service => (
               <div key={service._id} className="service-item">
                 <h3>{service.name}</h3>
                 <p>Provided by: {service.providerId ? service.providerId.name : 'Unknown Provider'}</p>

--- a/web/src/components/pages/client/dashboard/ClientDashboard.jsx
+++ b/web/src/components/pages/client/dashboard/ClientDashboard.jsx
@@ -7,7 +7,7 @@ import '../dashboard/ClientDashboard.css';
 
 const ClientHomePage = () => {
   const [user, setUser] = useState({ name: 'Guest', role: 'client', rating: '3' });
-  const [services, setServices] = useState([]);
+  const [, setServices] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState(null);
 
@@ -43,6 +43,30 @@ const ClientHomePage = () => {
 
   if (isLoading) return <div>Loading...</div>;
   if (error) return <div>Error: {error}</div>;
+
+  const serv = [
+        {
+            id: 1,
+            name: 'Web Development',
+            description: 'Web Development',
+            price: 1000,
+            providerId: {
+                id: '02',
+                name: 'Josue Batey',
+            }
+    },
+    {
+            id: 2,
+            name: 'Mobile Development',
+            description: 'iOS Development',
+            price: 1000,
+            providerId: {
+                id: '02',
+                name: 'Josue Batey',
+            }
+    }
+]
+
   return (
     <>
       <Header />
@@ -56,18 +80,22 @@ const ClientHomePage = () => {
         </section>
 
         <section className="services-overview">
-                    <h2>Explore Services</h2>
-                    <div className="services-list">
-                        {services.map(service => (
-                            <div key={service._id} className="service-item">
-                                <h3>{service.name}</h3>
-                                <p>Provided by: {service.providerId ? service.providerId.name : 'Unknown Provider'}</p>
-                                <p>{service.description}</p>
-                                <p>Price: ${service.price}</p>
-                            </div>
-                        ))}
-                    </div>
-                </section>
+          <h2>Explore Services</h2>
+          <div className="services-list">
+            {serv.map(service => (
+              <div key={service._id} className="service-item">
+                <h3>{service.name}</h3>
+                <p>Provided by: {service.providerId ? service.providerId.name : 'Unknown Provider'}</p>
+                <p>{service.description}</p>
+                <p>Price: ${service.price}</p>
+              </div>
+            ))}
+          </div>
+          <Link to="/clientservices" className="show_more__btn">
+            <span>Show More</span>
+            <span className="material-symbols-outlined">arrow_forward</span>
+          </Link>
+        </section>
 
         <section className="projects-section">
           <h2>My Projects</h2>

--- a/web/src/components/pages/client/services/ClientServicesPages.css
+++ b/web/src/components/pages/client/services/ClientServicesPages.css
@@ -37,6 +37,12 @@
     color: #666;
     margin-bottom: 10px;
   }
+
+  
+  .no__data {
+    font-size: 2rem;
+    opacity: .45;
+  }
   
   /* Responsive adjustments */
   @media (max-width: 768px) {

--- a/web/src/components/pages/client/services/ClientServicesPages.jsx
+++ b/web/src/components/pages/client/services/ClientServicesPages.jsx
@@ -17,11 +17,11 @@ const ClientServicesPage = () => {
                 setServices(response.data); // Adjust according to your actual response structure
                 setIsLoading(false);
             } catch (err) {
-                console.error('Error fetching random services:', err);
+                setError('Error fetching random services:', err);
                 setIsLoading(false);
             }
         };
-      
+
         fetchRandomServices();
     }, []);
 
@@ -34,14 +34,19 @@ const ClientServicesPage = () => {
             <div className="client-services-page">
                 <h2>Available Services</h2>
                 <div className="services-list">
-                    {services.map(service => (
+                    {
+                        services.length ?
+                            (
+                                services.map(service => (
                         <div key={service._id} className="service-item">
                             <h3>{service.name}</h3>
                             <p>Provided by: {service.providerId ? service.providerId.name : 'Unknown Provider'}</p> 
                             <p>{service.description}</p>
                             <p>Price: ${service.price}</p>
                         </div>
-                    ))}
+                        
+                    ))): (<div className="no__data">No service is available at the moment</div>)
+                    }
                 </div>
             </div>
             <Footer />

--- a/web/src/components/pages/client/services/ClientServicesPages.jsx
+++ b/web/src/components/pages/client/services/ClientServicesPages.jsx
@@ -7,7 +7,7 @@ import '../services/ClientServicesPages.css';
 const ClientServicesPage = () => {
     const [services, setServices] = useState([]);
     const [isLoading, setIsLoading] = useState(true);
-    // const [error, setError] = useState(null);
+    const [error, setError] = useState(null);
 
     useEffect(() => {
         const fetchRandomServices = async () => {
@@ -26,6 +26,8 @@ const ClientServicesPage = () => {
     }, []);
 
     if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error: {error}</div>;
+
 
     return (
         <>

--- a/web/src/components/pages/provider/dashboard/ProviderDashboard.jsx
+++ b/web/src/components/pages/provider/dashboard/ProviderDashboard.jsx
@@ -67,6 +67,10 @@ const ProviderHomePage = () => {
               </div>
             ))}
           </div>
+          <Link to="/providerservices" className="show_more__btn">
+            <span>Show More</span>
+            <span className="material-symbols-outlined">arrow_forward</span>
+          </Link>
         </section>
 
         <section className="client-projects">


### PR DESCRIPTION
## Task Description

In this PR, I implemented the following changes  add show more button to the client and provider dashboard services section

- [x] Add and style the Show More button to navigate to all services
- [x] set the error and display it when occurs on the client service pages
- [x] display message when there is no message available

![show more ok](https://github.com/AhmedRaisi/Tarsho/assets/52311487/76f3f2d4-3b87-4b09-9e2d-0d47ae978cd9)
